### PR TITLE
Fix dice roll overrides leaking into cover interception rolls; add dedicated cover interception options

### DIFF
--- a/ToyBox/Classes/Features/BagOfTricks/DiceRolls/DiceRollsOverridesFeature.cs
+++ b/ToyBox/Classes/Features/BagOfTricks/DiceRolls/DiceRollsOverridesFeature.cs
@@ -168,7 +168,7 @@ public partial class DiceRollsOverridesFeature : FeatureWithPatch {
     // Force its outcome here instead of letting the generic dice overrides leak into it.
     [HarmonyPatch(typeof(RuleRollCoverHit), nameof(RuleRollCoverHit.OnTrigger)), HarmonyPostfix]
     private static void RuleRollCoverHit_OnTrigger_Patch(RuleRollCoverHit __instance) {
-        // Invisible cover is a wall; never mess with it.
+        // Invisible cover has a hardcoded 100% chance, i.e. the game never wants the attack to miss it. Leave it alone.
         if (__instance.HitChanceRule.Los == LosCalculations.CoverType.Invisible) {
             return;
         }
@@ -365,10 +365,10 @@ public partial class DiceRollsOverridesFeature : FeatureWithPatch {
     private static partial string m_DamageRolls_Take1LocalizedText { get; }
     [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_AttackRolls__LowerIsBetterLocalizedText", "Attack Rolls -> Lower is better")]
     private static partial string m_AttackRolls__LowerIsBetterLocalizedText { get; }
-    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverInterception_UsesASeparateRoLocalizedText", "Cover Interception -> Lower is better for the defender; uses a separate roll, not affected by the dice overrides above")]
+    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverInterception_UsesASeparateRoLocalizedText", "Controls whether attacks made by the selected units are redirected to cover instead of their target.")]
     private static partial string m_CoverInterception_UsesASeparateRoLocalizedText { get; }
-    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverNeverInterceptsLocalizedText", "Cover: Never Intercepts")]
+    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverNeverInterceptsLocalizedText", "Cover: Never Redirect")]
     private static partial string m_CoverNeverInterceptsLocalizedText { get; }
-    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverAlwaysInterceptsLocalizedText", "Cover: Always Intercepts")]
+    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverAlwaysInterceptsLocalizedText", "Cover: Always Redirect")]
     private static partial string m_CoverAlwaysInterceptsLocalizedText { get; }
 }

--- a/ToyBox/Classes/Features/BagOfTricks/DiceRolls/DiceRollsOverridesFeature.cs
+++ b/ToyBox/Classes/Features/BagOfTricks/DiceRolls/DiceRollsOverridesFeature.cs
@@ -3,6 +3,7 @@ using Kingmaker.RuleSystem;
 using Kingmaker.RuleSystem.Rules;
 using Kingmaker.RuleSystem.Rules.Damage;
 using Kingmaker.RuleSystem.Rules.Starships;
+using Kingmaker.View.Covers;
 using ToyBox.Infrastructure.Utilities;
 using UnityEngine;
 using static Kingmaker.RuleSystem.RulebookEvent;
@@ -32,7 +33,7 @@ public partial class DiceRollsOverridesFeature : FeatureWithPatch {
         m_NeverRoll1LocalizedText, m_DamageRolls_Take1LocalizedText, m_DamageRolls_Take25LocalizedText, m_DamageRolls_Take50LocalizedText,
         m_OutOfCombat_Take1LocalizedText, m_OutOfCombat_Take25LocalizedText, m_OutOfCombat_Take50LocalizedText, m_SkillChecks_Take1LocalizedText,
         m_SkillChecks_Take25LocalizedText, m_SkillChecks_Take50LocalizedText, m_Take100LocalizedText, m_Take1LocalizedText,
-        m_Take50LocalizedText], GUI.skin.label));
+        m_Take50LocalizedText, m_CoverNeverInterceptsLocalizedText, m_CoverAlwaysInterceptsLocalizedText], GUI.skin.label));
     public override void OnGui() {
         base.OnGui();
         if (IsEnabled) {
@@ -57,6 +58,7 @@ public partial class DiceRollsOverridesFeature : FeatureWithPatch {
                         UI.Label(m_RollWithDisadvantageLocalizedText, Width(labelWidth));
                         UI.SelectionGrid(ref Settings.DiceRollsRollWithDisadvantage, 8, e => e.GetLocalized(), Width(0.7f * EffectiveWindowWidth()));
                     }
+                    UI.Label(m_AttackRolls__LowerIsBetterLocalizedText.Green());
                     using (HorizontalScope()) {
                         UI.Label(m_Take100LocalizedText, Width(labelWidth));
                         UI.SelectionGrid(ref Settings.DiceRollsAlwaysRoll100, 8, e => e.GetLocalized(), Width(0.7f * EffectiveWindowWidth()));
@@ -76,6 +78,15 @@ public partial class DiceRollsOverridesFeature : FeatureWithPatch {
                     using (HorizontalScope()) {
                         UI.Label(m_NeverRoll1LocalizedText, Width(labelWidth));
                         UI.SelectionGrid(ref Settings.DiceRollsNeverRoll1, 8, e => e.GetLocalized(), Width(0.7f * EffectiveWindowWidth()));
+                    }
+                    UI.Label(m_CoverInterception_UsesASeparateRoLocalizedText.Green());
+                    using (HorizontalScope()) {
+                        UI.Label(m_CoverNeverInterceptsLocalizedText, Width(labelWidth));
+                        UI.SelectionGrid(ref Settings.DiceRollsCoverNeverIntercept, 8, e => e.GetLocalized(), Width(0.7f * EffectiveWindowWidth()));
+                    }
+                    using (HorizontalScope()) {
+                        UI.Label(m_CoverAlwaysInterceptsLocalizedText, Width(labelWidth));
+                        UI.SelectionGrid(ref Settings.DiceRollsCoverAlwaysIntercept, 8, e => e.GetLocalized(), Width(0.7f * EffectiveWindowWidth()));
                     }
                     using (HorizontalScope()) {
                         UI.Label(m_OutOfCombat_Take50LocalizedText, Width(labelWidth));
@@ -153,6 +164,20 @@ public partial class DiceRollsOverridesFeature : FeatureWithPatch {
             __instance.ResultIsCrit = true;
         }
     }
+    // Cover interception is rolled separately from the attack roll (RuleRollCoverHit uses its own Dice.D100).
+    // Force its outcome here instead of letting the generic dice overrides leak into it.
+    [HarmonyPatch(typeof(RuleRollCoverHit), nameof(RuleRollCoverHit.OnTrigger)), HarmonyPostfix]
+    private static void RuleRollCoverHit_OnTrigger_Patch(RuleRollCoverHit __instance) {
+        // Invisible cover is a wall; never mess with it.
+        if (__instance.HitChanceRule.Los == LosCalculations.CoverType.Invisible) {
+            return;
+        }
+        if (ToyBoxUnitHelper.IsOfSelectedType(__instance.InitiatorUnit, Settings.DiceRollsCoverNeverIntercept)) {
+            __instance.ResultIsHit = false;
+        } else if (ToyBoxUnitHelper.IsOfSelectedType(__instance.InitiatorUnit, Settings.DiceRollsCoverAlwaysIntercept) && !__instance.m_IsAutoMissCover && !__instance.HitChanceRule.IsAutoMiss) {
+            __instance.ResultIsHit = true;
+        }
+    }
     [HarmonyPatch(typeof(RuleRollInitiative), nameof(RuleRollInitiative.ResultD10), MethodType.Getter), HarmonyPostfix]
     private static void RuleRollInitiative_getResultD10_Patch(ref RuleRollD10 __result, RuleRollInitiative __instance) {
         if (ToyBoxUnitHelper.IsOfSelectedType(__instance.InitiatorUnit, Settings.DiceRollsInitiativeAlwaysRoll1)) {
@@ -213,6 +238,10 @@ public partial class DiceRollsOverridesFeature : FeatureWithPatch {
                     __instance.m_RerollAmount = 0;
                     __instance.Reroll();
                 }
+                return;
+            } else if (evt is RuleRollCoverHit) {
+                // Cover interception is decided by its own d100 roll (Dice.D100 inside RuleRollCoverHit).
+                // Leave it untouched here; it is controlled by the dedicated Cover Interception settings below.
                 return;
             } else if (evt is RuleDealDamage) {
                 isDamageRule = true;
@@ -334,4 +363,12 @@ public partial class DiceRollsOverridesFeature : FeatureWithPatch {
     private static partial string m_DamageRolls_Take25LocalizedText { get; }
     [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_DamageRolls_Take1LocalizedText", "Damage Rolls: Take 1")]
     private static partial string m_DamageRolls_Take1LocalizedText { get; }
+    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_AttackRolls__LowerIsBetterLocalizedText", "Attack Rolls -> Lower is better")]
+    private static partial string m_AttackRolls__LowerIsBetterLocalizedText { get; }
+    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverInterception_UsesASeparateRoLocalizedText", "Cover Interception -> Lower is better for the defender; uses a separate roll, not affected by the dice overrides above")]
+    private static partial string m_CoverInterception_UsesASeparateRoLocalizedText { get; }
+    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverNeverInterceptsLocalizedText", "Cover: Never Intercepts")]
+    private static partial string m_CoverNeverInterceptsLocalizedText { get; }
+    [LocalizedString("ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverAlwaysInterceptsLocalizedText", "Cover: Always Intercepts")]
+    private static partial string m_CoverAlwaysInterceptsLocalizedText { get; }
 }

--- a/ToyBox/Classes/Infrastructure/Settings/GeneralSettings.cs
+++ b/ToyBox/Classes/Infrastructure/Settings/GeneralSettings.cs
@@ -191,6 +191,8 @@ public class GeneralSettings : AbstractJsonSettings {
     public UnitSelectType DiceRollsAlwaysRoll1;
     public UnitSelectType DiceRollsNeverRoll100;
     public UnitSelectType DiceRollsNeverRoll1;
+    public UnitSelectType DiceRollsCoverNeverIntercept;
+    public UnitSelectType DiceRollsCoverAlwaysIntercept;
     public UnitSelectType DiceRollsInitiativeAlwaysRoll10;
     public UnitSelectType DiceRollsInitiativeAlwaysRoll5;
     public UnitSelectType DiceRollsInitiativeAlwaysRoll1;

--- a/ToyBox/Localization/en_lang.json
+++ b/ToyBox/Localization/en_lang.json
@@ -572,15 +572,15 @@
     "Translated": null
   },
   "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverInterception_UsesASeparateRoLocalizedText": {
-    "Original": "Cover Interception -> Lower is better for the defender; uses a separate roll, not affected by the dice overrides above",
+    "Original": "Controls whether attacks made by the selected units are redirected to cover instead of their target.",
     "Translated": null
   },
   "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverNeverInterceptsLocalizedText": {
-    "Original": "Cover: Never Intercepts",
+    "Original": "Cover: Never Redirect",
     "Translated": null
   },
   "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverAlwaysInterceptsLocalizedText": {
-    "Original": "Cover: Always Intercepts",
+    "Original": "Cover: Always Redirect",
     "Translated": null
   },
   "ToyBox_Features_BagOfTricks_EnemyStatModifier_EnemyFlatStatModifierFeature_Name": {

--- a/ToyBox/Localization/en_lang.json
+++ b/ToyBox/Localization/en_lang.json
@@ -567,6 +567,22 @@
     "Original": "Damage Rolls: Take 1",
     "Translated": null
   },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_AttackRolls__LowerIsBetterLocalizedText": {
+    "Original": "Attack Rolls -> Lower is better",
+    "Translated": null
+  },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverInterception_UsesASeparateRoLocalizedText": {
+    "Original": "Cover Interception -> Lower is better for the defender; uses a separate roll, not affected by the dice overrides above",
+    "Translated": null
+  },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverNeverInterceptsLocalizedText": {
+    "Original": "Cover: Never Intercepts",
+    "Translated": null
+  },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverAlwaysInterceptsLocalizedText": {
+    "Original": "Cover: Always Intercepts",
+    "Translated": null
+  },
   "ToyBox_Features_BagOfTricks_EnemyStatModifier_EnemyFlatStatModifierFeature_Name": {
     "Original": "Flat Enemy Stat Modifier",
     "Translated": null

--- a/ToyBox/Localization/ru_lang.json
+++ b/ToyBox/Localization/ru_lang.json
@@ -572,15 +572,15 @@
     "Translated": null
   },
   "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverInterception_UsesASeparateRoLocalizedText": {
-    "Original": "Cover Interception -> Lower is better for the defender; uses a separate roll, not affected by the dice overrides above",
+    "Original": "Controls whether attacks made by the selected units are redirected to cover instead of their target.",
     "Translated": null
   },
   "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverNeverInterceptsLocalizedText": {
-    "Original": "Cover: Never Intercepts",
+    "Original": "Cover: Never Redirect",
     "Translated": null
   },
   "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverAlwaysInterceptsLocalizedText": {
-    "Original": "Cover: Always Intercepts",
+    "Original": "Cover: Always Redirect",
     "Translated": null
   },
   "ToyBox_Features_BagOfTricks_EnemyStatModifier_EnemyFlatStatModifierFeature_Name": {

--- a/ToyBox/Localization/ru_lang.json
+++ b/ToyBox/Localization/ru_lang.json
@@ -567,6 +567,22 @@
     "Original": "Damage Rolls: Take 1",
     "Translated": null
   },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_AttackRolls__LowerIsBetterLocalizedText": {
+    "Original": "Attack Rolls -> Lower is better",
+    "Translated": null
+  },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverInterception_UsesASeparateRoLocalizedText": {
+    "Original": "Cover Interception -> Lower is better for the defender; uses a separate roll, not affected by the dice overrides above",
+    "Translated": null
+  },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverNeverInterceptsLocalizedText": {
+    "Original": "Cover: Never Intercepts",
+    "Translated": null
+  },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverAlwaysInterceptsLocalizedText": {
+    "Original": "Cover: Always Intercepts",
+    "Translated": null
+  },
   "ToyBox_Features_BagOfTricks_EnemyStatModifier_EnemyFlatStatModifierFeature_Name": {
     "Original": "Flat Enemy Stat Modifier",
     "Translated": null

--- a/ToyBox/Localization/zh-CN_lang.json
+++ b/ToyBox/Localization/zh-CN_lang.json
@@ -567,6 +567,22 @@
     "Original": "Damage Rolls: Take 1",
     "Translated": "伤害掷骰：固定取 1"
   },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_AttackRolls__LowerIsBetterLocalizedText": {
+    "Original": "Attack Rolls -> Lower is better",
+    "Translated": "攻击掷骰 → 数值越低越好"
+  },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverInterception_UsesASeparateRoLocalizedText": {
+    "Original": "Cover Interception -> Lower is better for the defender; uses a separate roll, not affected by the dice overrides above",
+    "Translated": "掩体拦截 → 数值越低对防守方越有利；使用独立骰子，不受上方掷骰覆盖影响"
+  },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverNeverInterceptsLocalizedText": {
+    "Original": "Cover: Never Intercepts",
+    "Translated": "掩体：永不拦截"
+  },
+  "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverAlwaysInterceptsLocalizedText": {
+    "Original": "Cover: Always Intercepts",
+    "Translated": "掩体：永远拦截"
+  },
   "ToyBox_Features_BagOfTricks_EnemyStatModifier_EnemyFlatStatModifierFeature_Name": {
     "Original": "Flat Enemy Stat Modifier",
     "Translated": "敌人属性固定加值"
@@ -2317,7 +2333,7 @@
   },
   "ToyBox_Features_Saves_ChangeSaveIdFeature_m_N_ALocalizedText": {
     "Original": "N/A",
-    "Translated": "N/A"
+    "Translated": null
   },
   "ToyBox_Features_Saves_SavesFeatureTab_Name": {
     "Original": "Saves",

--- a/ToyBox/Localization/zh-CN_lang.json
+++ b/ToyBox/Localization/zh-CN_lang.json
@@ -572,16 +572,16 @@
     "Translated": "攻击掷骰 → 数值越低越好"
   },
   "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverInterception_UsesASeparateRoLocalizedText": {
-    "Original": "Cover Interception -> Lower is better for the defender; uses a separate roll, not affected by the dice overrides above",
-    "Translated": "掩体拦截 → 数值越低对防守方越有利；使用独立骰子，不受上方掷骰覆盖影响"
+    "Original": "Controls whether attacks made by the selected units are redirected to cover instead of their target.",
+    "Translated": "控制所选单位的攻击是否被重定向到掩体而非其目标。"
   },
   "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverNeverInterceptsLocalizedText": {
-    "Original": "Cover: Never Intercepts",
-    "Translated": "掩体：永不拦截"
+    "Original": "Cover: Never Redirect",
+    "Translated": "掩体：从不重定向"
   },
   "ToyBox_Features_BagOfTricks_DiceRolls_DiceRollsOverridesFeature_m_CoverAlwaysInterceptsLocalizedText": {
-    "Original": "Cover: Always Intercepts",
-    "Translated": "掩体：永远拦截"
+    "Original": "Cover: Always Redirect",
+    "Translated": "掩体：始终重定向"
   },
   "ToyBox_Features_BagOfTricks_EnemyStatModifier_EnemyFlatStatModifierFeature_Name": {
     "Original": "Flat Enemy Stat Modifier",

--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="$(SolutionDir)GamePathFinder.props" Condition="Exists('$(SolutionDir)GamePathFinder.props')" />
 	<PropertyGroup>
 		<TargetFramework>net481</TargetFramework>
@@ -72,7 +72,7 @@
 		<ZipDirectory SourceDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" DestinationFile="$(MSBuildProjectDirectory)\$(OutputPath)\..\$(AssemblyName)-$(Version).zip" Overwrite="true" />
 	</Target>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
 		<PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" IncludeAssets="build; contentfiles" Version="0.4.2" PrivateAssets="all" />
 		<PackageReference Include="MicroUtils.HarmonyAnalyzers" IncludeAssets="runtime; build; native; contentfiles; analyzers" Version="*-*" PrivateAssets="all" />
 		<PackageReference Include="ToyBox.BuildTools" IncludeAssets="analyzers; build; compile" Version="1.1.9.5" PrivateAssets="all" />

--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="$(SolutionDir)GamePathFinder.props" Condition="Exists('$(SolutionDir)GamePathFinder.props')" />
 	<PropertyGroup>
 		<TargetFramework>net481</TargetFramework>
@@ -72,7 +72,7 @@
 		<ZipDirectory SourceDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" DestinationFile="$(MSBuildProjectDirectory)\$(OutputPath)\..\$(AssemblyName)-$(Version).zip" Overwrite="true" />
 	</Target>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
 		<PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" IncludeAssets="build; contentfiles" Version="0.4.2" PrivateAssets="all" />
 		<PackageReference Include="MicroUtils.HarmonyAnalyzers" IncludeAssets="runtime; build; native; contentfiles; analyzers" Version="*-*" PrivateAssets="all" />
 		<PackageReference Include="ToyBox.BuildTools" IncludeAssets="analyzers; build; compile" Version="1.1.9.5" PrivateAssets="all" />


### PR DESCRIPTION
## The Problem

I ran into an issue: with "Take 1" enabled, attacking a target behind cover results in a **100% cover hit rate** — the exact opposite of the "all attacks hit" outcome players expect. "Take 50" against full cover produces the same 100% interception.

Root cause: "Take 1/50/100" (as well as Never Roll 1/100 and Advantage/Disadvantage) works by patching `RuleRollDice.Roll()`, which affects nearly every d100 rolled by that initiator. Cover interception, however, is a separate check: `RulePerformAttackRoll` triggers a `RuleRollCoverHit` after the attack roll, and it rolls via `Dice.D100` internally — which goes through the same patched method, so the generic dice override rewrites it too.

The interception check is `roll ≤ cover chance` (~35 for half cover, ~60 for full cover, modified by difficulty, capped at 95), and `CoverHit` takes priority over all other results. So "Take 1" makes the attack roll an automatic hit while also making the cover interception check (1 ≤ 60) an automatic success — every shot ends up hitting the cover.

This is the same class of issue as the previously fixed `TryNullifyDamage` leak (the "The Emperor Protects" damage-nullification roll making enemies invincible); that fix only covered the damage-nullification path, and the cover roll was never excluded.

## Changes

1. Added a `RuleRollCoverHit` branch to the event-stack check in `RuleRollDice_Roll_Patch` that returns immediately, so cover interception rolls are no longer affected by the generic dice overrides — consistent with how skill checks (`RulePerformSkillCheck`) and damage (`RuleDealDamage`) are already distinguished.
2. Added two dedicated settings (with the usual Main Character / Party / Allies / Enemies / Everyone columns, matching the existing style):
   - **Cover: Never Intercepts** — cover never intercepts attacks made by matching units;
   - **Cover: Always Intercepts** — cover always intercepts attacks made by matching units.

   Implemented as a postfix on `RuleRollCoverHit.OnTrigger` that writes `ResultIsHit` directly. Two safeguards: `Invisible` cover (walls) is never touched; interception is not forced when the attack auto-hits (`m_IsAutoMissCover`) or the cover rule itself auto-misses (`IsAutoMiss`).
3. Added direction hints to the panel: "Lower is better" for the attack roll section and "Lower is better for the defender" for the cover section. Previously only the Initiative / Skill Checks / Damage sections had such hints.

## Behavior Changes & Compatibility

- Both new options default to Off; existing settings files are fully compatible.
- With default settings, the only behavioral change is that cover interception rolls return to natural randomness instead of being distorted by the generic dice overrides. Everything else is unchanged.

## Testing

Tested on game version 1.6.1.511:
- "Take 1" (Main Character) attacking a target behind full cover: 100% cover hits before the fix; cover intercepts at its natural rate after;
- With "Cover: Never Intercepts" enabled, all attacks land normally;
- With no options enabled, cover behavior is identical to vanilla.

## A Related Observation (out of scope for this PR)

In 2.x, "All Attacks Hit" rewrites `Result` after `RulePerformAttackRoll.OnTrigger` and deliberately skips `CoverHit`, so it cannot bypass cover. In 1.x it was implemented via `AttackHitPolicyType.AutoHit`, and the game internally disables cover interception for auto-hit attacks (`isAutoMissCover`) — so it could bypass cover. This looks like a behavioral regression introduced by the rewrite. The new "Cover: Never Intercepts" option covers this use case, so this PR leaves "All Attacks Hit" untouched — but whether to restore the 1.x behavior is your call.
